### PR TITLE
feat: add pagination support for milestone and task retrieval

### DIFF
--- a/server/src/db/schema.helpers.ts
+++ b/server/src/db/schema.helpers.ts
@@ -1,7 +1,0 @@
-import { timestamp } from 'drizzle-orm/pg-core';
-
-export const timestamps = {
-  updated_at: timestamp(),
-  created_at: timestamp().defaultNow().notNull(),
-  deleted_at: timestamp()
-};

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -9,7 +9,11 @@ import {
   varchar
 } from 'drizzle-orm/pg-core';
 
-import { timestamps } from './schema.helpers.js';
+export const timestamps = {
+  updated_at: timestamp(),
+  created_at: timestamp().defaultNow().notNull(),
+  deleted_at: timestamp()
+};
 
 // TODO: Add more status levels
 export const statusEnum = pgEnum('status', [

--- a/server/src/milestones/controller.ts
+++ b/server/src/milestones/controller.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from 'express';
 import { z } from 'zod';
 
+import { Pagination } from '../utils/pagination.js';
 import type { IMilestoneService } from './service.js';
 
 const MilestoneFiltersSchema = z.object({
@@ -25,9 +26,10 @@ export class MilestoneController {
           error: 'Invalid filters',
           details: result.error.issues
         });
+        return;
       }
 
-      const milestones = await this.milestoneService.getMilestones(result.data);
+      const milestones = await this.milestoneService.getMilestones(result.data, Pagination(req));
       res.status(200).json(milestones);
     } catch (error) {
       res.status(500).json({ error: 'Failed to fetch milestones' });
@@ -47,7 +49,7 @@ export class MilestoneController {
   getMilestoneTasks = async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
-      const tasks = await this.milestoneService.getMilestoneTasks(Number(id));
+      const tasks = await this.milestoneService.getMilestoneTasks(Number(id), Pagination(req));
       res.status(200).json(tasks);
     } catch (error) {
       res.status(500).json({ error: 'Failed to fetch milestone tasks' });

--- a/server/src/tasks/controller.ts
+++ b/server/src/tasks/controller.ts
@@ -1,13 +1,14 @@
 import type { Request, Response } from 'express';
 
+import { Pagination } from '../utils/pagination.js';
 import type { ITaskService } from './service.js';
 
 export class TaskController {
   constructor(private readonly taskService: ITaskService) {}
 
-  getTasks = async (_: Request, res: Response) => {
+  getTasks = async (req: Request, res: Response) => {
     try {
-      const tasks = await this.taskService.getTasks();
+      const tasks = await this.taskService.getTasks(Pagination(req));
       res.status(200).json(tasks);
     } catch (error) {
       res.status(500).json({ error: 'Failed to fetch tasks' });

--- a/server/src/tasks/service.ts
+++ b/server/src/tasks/service.ts
@@ -3,9 +3,11 @@ import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { type RowList } from 'postgres';
 
 import { type Task, tasks } from '../db/schema.js';
+import { DEFAULT_PAGE, DEFAULT_PAGE_SIZE } from '../utils/const.js';
+import type { Pagination } from '../utils/pagination.js';
 
 export interface ITaskService {
-  getTasks(): Promise<Task[]>;
+  getTasks(pagination?: Pagination): Promise<Task[]>;
   getTask(id: number): Promise<Task | undefined>;
   updateTask(id: number, task: Task): Promise<Task[]>;
   deleteTask(id: number): Promise<RowList<never[]>>;
@@ -14,8 +16,12 @@ export interface ITaskService {
 export class TaskService implements ITaskService {
   constructor(private readonly db: PostgresJsDatabase<Record<string, never>>) {}
 
-  async getTasks() {
-    return await this.db.select().from(tasks);
+  async getTasks(pagination?: Pagination) {
+    return await this.db
+      .select()
+      .from(tasks)
+      .limit(pagination?.pageSize ?? DEFAULT_PAGE_SIZE)
+      .offset((pagination?.page ?? DEFAULT_PAGE - 1) * (pagination?.pageSize ?? DEFAULT_PAGE_SIZE));
   }
 
   async getTask(id: number) {

--- a/server/src/utils/const.ts
+++ b/server/src/utils/const.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_PAGE = 1;
+export const DEFAULT_PAGE_SIZE = 10;


### PR DESCRIPTION
This pull request introduces pagination support for the retrieval of milestones and tasks. The implementation allows users to fetch results in a paginated manner, improving the efficiency and usability of the application when dealing with large datasets. The changes include modifications to the API endpoints to accept pagination parameters and adjustments to the data retrieval logic to handle these parameters effectively.